### PR TITLE
Remove extra comma in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		}
 	],
 	"autoload": {
-		"psr-4": {"HtmlGenerator\\": ""},
+		"psr-4": {"HtmlGenerator\\": ""}
 	},
 	"support": {
 		"issues": "https://github.com/Airmanbzh/php-html-generator/issues"


### PR DESCRIPTION
I've accidentally added extra comma in #6. Now it's fixed
