### PR TITLE
Implements ArrayAccess for Markup class

### DIFF
--- a/Markup.php
+++ b/Markup.php
@@ -4,7 +4,9 @@
  */
 namespace HtmlGenerator;
 
-class Markup
+use ArrayAccess;
+
+class Markup implements ArrayAccess
 {
     protected static $_instance = null;
 
@@ -97,6 +99,52 @@ class Markup
     public function attr($name, $value)
     {
         return $this->set($name, $value);
+    }
+
+    /**
+     * Checks if an attribute is set for this tag and not null
+     *
+     * @param string $attribute The attribute to test
+     * @return boolean The result of the test
+     */
+    public function offsetExists($attribute)
+    {
+        return isset($this->attributeList[$attribute]);
+    }
+
+    /**
+     * Returns the value the attribute set for this tag
+     *
+     * @param string $attribute The attribute to get
+     * @return mixed The stored result in this object
+     */
+    public function offsetGet($attribute)
+    {
+        return $this->offsetExists($attribute) ? $this->attributeList[$attribute] : trigger_error('Unfinded index "'.$attribute.'"');
+    }
+
+    /**
+     * Sets the value an attribute for this tag
+     *
+     * @param string $attribute The attribute to set
+     * @param mixed $value The value to set
+     * @return void
+     */
+    public function offsetSet($attribute, $value)
+    {
+        $this->attributeList[$attribute] = $value;
+    }
+
+    /**
+     * Removes an attribute
+     *
+     * @param mixed $attribute The attribute to unset
+     * @return void
+     */
+    public function offsetUnset($attribute)
+    {
+        if ($this->offsetExists($attribute))
+            unset($this->attributeList[$attribute]);
     }
 
     /**

--- a/Markup.php
+++ b/Markup.php
@@ -120,7 +120,7 @@ class Markup implements ArrayAccess
      */
     public function offsetGet($attribute)
     {
-        return $this->offsetExists($attribute) ? $this->attributeList[$attribute] : trigger_error('Unfinded index "'.$attribute.'"');
+        return $this->offsetExists($attribute) ? $this->attributeList[$attribute] : null;
     }
 
     /**


### PR DESCRIPTION
It allows to change a markup's attributes as the object is an array :

```php
<?php
$tag = $html->tag('a')->text('Google');
$tag['src'] = 'http://google.com/';
?>
```