### PR TITLE
Update HtmlTag.php

### DIFF
--- a/HtmlTag.php
+++ b/HtmlTag.php
@@ -6,6 +6,9 @@ namespace HtmlGenerator;
 
 class HtmlTag extends Markup
 {
+    /** @var int The language convention used for XSS avoiding */
+    public static $outputLanguage = ENT_HTML5;
+
     protected $autocloseTagsList = array(
         'img', 'br', 'hr', 'input', 'area', 'link', 'meta', 'param'
     );
@@ -45,26 +48,5 @@ class HtmlTag extends Markup
             unset($this->attributeList['class'][array_search($value, $this->attributeList['class'])]);
         }
         return $this;
-    }
-
-    /**
-     * Returns current list of attributes as a string $key="$val" $key2="$val2"
-     * Overrides the parent function to allow boolean value
-     * @return string
-     */
-    protected function attributesToString()
-    {
-        $string = '';
-        if (!is_null($this->attributeList)) {
-            foreach ($this->attributeList as $key => $value) {
-                if ($value!==false) {
-                    $string.= ' ' . $key;
-                    if ($value!==true) {
-                        $string.= '="' . (is_array($value) ? implode(' ', $value) : $value ) . '"';
-                    }
-                }
-            }
-        }
-        return $string;
     }
 }

--- a/HtmlTag.php
+++ b/HtmlTag.php
@@ -46,4 +46,25 @@ class HtmlTag extends Markup
         }
         return $this;
     }
+
+    /**
+     * Returns current list of attributes as a string $key="$val" $key2="$val2"
+     * Overrides the parent function to allow boolean value
+     * @return string
+     */
+    protected function attributesToString()
+    {
+        $string = '';
+        if (!is_null($this->attributeList)) {
+            foreach ($this->attributeList as $key => $value) {
+                if ($value!==false) {
+                    $string.= ' ' . $key;
+                    if ($value!==true) {
+                        $string.= '="' . (is_array($value) ? implode(' ', $value) : $value ) . '"';
+                    }
+                }
+            }
+        }
+        return $string;
+    }
 }


### PR DESCRIPTION
Adapt HTMLTag class to match HTML representation of boolean attributes when a boolean value is set to an attribute.

```php
<?php
$tag = $html->tag('input')
    ->set('autofocus', isset($_POST['some_value']))
    ->set('disabled', !isset($_POST['some_value']));
echo $tag;
?>
```

This will output :

```html
<!-- If "some_value" key has been POST -->
<input autofocus/>
<!-- Else -->
<input disabled/>
```