### PR TITLE
Shortcut static call to create a markup

### DIFF
--- a/Markup.php
+++ b/Markup.php
@@ -41,6 +41,17 @@ class Markup
     }
 
     /**
+     * Builds markup from static context
+     * @param string $tag The tag name
+     * @param array  $content The content of the current tag
+     * @return Markup
+     */
+    public static function __callStatic($tag, $content)
+    {
+        return self::createElement($tab)->text(implode('', $content));
+    }
+
+    /**
      * Create a new Markup
      * @param string $tag
      * @return Markup instance


### PR DESCRIPTION
Here is a new way to create a markup / a HTML tag:

```php
<?php
echo HtmlTag::p('Hello world!'); // Will print: "<p>Hello World!</p>"
echo HtmlTag::br(); // Will print "<br/>"
echo HtmlTag::div('We will '.HTML::b('ROCK YOU!'))->addClass('pop-up'); // Will print "<div class="pop-up">We will <b>ROCK YOU!</b></div>"
echo HtmlTag::div('We will ', HTML::b('ROCK YOU!'))->addClass('pop-up'); // Same as above
?>
```